### PR TITLE
Check if argument is a dir or a mount point

### DIFF
--- a/rmfuse/fuse.py
+++ b/rmfuse/fuse.py
@@ -398,6 +398,14 @@ def main():
         logging.basicConfig(level=logging.INFO)
         # Fuse debug is really verbose, so stick that here.
         fuse_options.add('debug')
+    
+    if not os.path.isdir(options.mountpoint):
+        log.error(f'{options.mountpoint} directory does not exist')
+        return
+    elif os.path.ismount(options.mountpoint):
+        log.error(f'{options.mountpoint} is a mount point already')
+        return
+    
     pyfuse3.init(fs, options.mountpoint, fuse_options)
     try:
         trio.run(pyfuse3.main)
@@ -405,6 +413,6 @@ def main():
         log.debug('Exiting due to KeyboardInterrupt')
     finally:
         pyfuse3.close()
-
+        
 if __name__ == '__main__':
     main()

--- a/rmfuse/fuse.py
+++ b/rmfuse/fuse.py
@@ -413,6 +413,5 @@ def main():
         log.debug('Exiting due to KeyboardInterrupt')
     finally:
         pyfuse3.close()
-        
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Fuse has errors if trying to mount the file system on an existing mount point or if the path is not a directory or does not exist.
So, rmfuse will mount the file system only if these conditions are fulfilled.