### PR TITLE
Update one-time-code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ rmfuse ~/remarkable
 
 The first time RMfuse is run, it will need a _one-time code_ to get
 access to your reMarkable Cloud account.  You will be prompted to get
-that code from https://my.remarkable.com/connect/desktop, which may
+that code from https://my.remarkable.com/#desktop, which may
 require logging in to your reMarkable account.  RMfuse uses that code
 to obtain tokens which it uses in the future to authenticate itself.
 


### PR DESCRIPTION
Looks like there's already a PR in rmcl to update the one-time-code link (https://github.com/rschroll/rmcl/pull/8). This PR updates the README which references a dead link.