### PR TITLE
Fix isconnected check

### DIFF
--- a/rmfuse/fuse.py
+++ b/rmfuse/fuse.py
@@ -505,7 +505,7 @@ def parse_args():
     parser.add_argument('--version', action='version', version=VERSION)
     return parser.parse_args()
 
-def isconnected(host='1.1.1.1', port=80, timeout=1):
+def isconnected(host='api.store.remarkable.com', port=80, timeout=5):
     # timeout is expressed in seconds
     try:
         s = socket.create_connection((host, port), timeout)


### PR DESCRIPTION
The IP 1.1.1.1 is not reachable in my country on port 80.

To fix this, I propose actually checking, if the reMarkable service itself is online.

This domain replies with a small webpage and is perfectly suited to this purpose.